### PR TITLE
Problem: CI fail because builddir is not needed for tntdb master

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -136,7 +136,7 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
     cd "${BASE_PWD}"
     git clone --quiet --depth 1 -b master https://github.com/maekitalo/tntdb tntdb.git
     BASE_PWD=${PWD}
-    cd tntdb.git/tntdb
+    cd tntdb.git
     git --no-pager log --oneline -n1
     if [ -e autogen.sh ]; then
         ./autogen.sh 2> /dev/null

--- a/project.xml
+++ b/project.xml
@@ -31,8 +31,7 @@
     <use project = "tntdb" test="tntdb::Date::gmtime"
         repository = "https://github.com/maekitalo/tntdb"
         release = "master"
-        builddir = "tntdb">
-    </use>
+    />
     <!-- use project = "tntdb" test="tntdb::connectCached" header="tntdb/connect.h" / -->
 
     <class name = "metricinfo" private="1"> Measurement</class>


### PR DESCRIPTION
Solution: remove builddir and regenerate CI build file

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>