### PR TITLE
Problem: CI fail because there is no more autogen.sh in tntdb

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -140,6 +140,10 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] ; the
     git --no-pager log --oneline -n1
     if [ -e autogen.sh ]; then
         ./autogen.sh 2> /dev/null
+    else
+        if [ -e configure.ac -o -e configure.in ]; then
+            autoreconf -fiv
+        fi
     fi
     if [ -e buildconf ]; then
         ./buildconf 2> /dev/null


### PR DESCRIPTION
Solution: call autoreconf if there is no autogen.sh

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>