### PR TITLE
PROBLEM: DB credentials missing

### DIFF
--- a/src/fty-metric-tpower.service.in
+++ b/src/fty-metric-tpower.service.in
@@ -1,9 +1,12 @@
 [Unit]
-Description=fty-metric-tpower service
-After=network.target
+Description=Total power agent for 42ITy project
+After=malamute.service bios-db-init.service
+Requires=malamute.service bios-db-init.service
+PartOf=bios.target
 
 [Service]
 Type=simple
+User=bios
 Environment="prefix=@prefix@"
 EnvironmentFile=-/etc/default/bios-db-ro
 EnvironmentFile=-/usr/share/bios/etc/default/bios


### PR DESCRIPTION
After deploying image, the following problem occured:
```bash
Jan 24 14:38:53 eaton-rc-002085ec0021 fty-metric-tpower[3633]: E:17-01-24 14:38:53 Failed to read configuration from database. Excepton caught: 'Mysql-Error 1045 in mysql_real_connect: Access denied for user 'root'@'localhost' (using password: NO)'.
```
I.e. Environment variables DB_USER, DB_PASSWD were not set for this unit

SOLUTION: Fix it!

Signed-off-by: Karol Hrdina <KarolHrdina@Eaton.com>