### PR TITLE
Problem: isnan() is from std::

### DIFF
--- a/src/tp_unit.cc
+++ b/src/tp_unit.cc
@@ -123,14 +123,14 @@ MetricInfo TPUnit::
 
         // detect a mix of single and three phase devices - return NAN for this case
         if (phases == "n/a") {
-            if (isnan (roL2))
+            if (std::isnan (roL2))
                 phases = "single";
             else
                 phases = "three";
         }
         else {
-            if ((isnan (roL2) && phases == "three") ||
-                (!isnan (roL2) && phases == "single")) {
+            if ((std::isnan (roL2) && phases == "three") ||
+                (!std::isnan (roL2) && phases == "single")) {
                 return MetricInfo ( _name, quantity, "W", NAN, ::time (NULL), "", TTL);
             }
         }


### PR DESCRIPTION
Solution: tp_unit.cc : fix isnan() => std::isnan()

Should address issue #24 as well (though I re-got the error on target platform just with stricter compilation settings).