### PR TITLE
Simplify malamute connection setup and add error handling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -63,6 +63,7 @@ EXTRA_DIST += \
     src/metriclist.h \
     src/tp_unit.h \
     src/proto_metric_unavailable.h \
+    src/fty_mlm.h \
     README.md \
     src/fty_metric_tpower_classes.h
 

--- a/project.xml
+++ b/project.xml
@@ -60,6 +60,7 @@
         />
     <!-- use project = "tntdb" test="tntdb::connectCached" header="tntdb/connect.h" / -->
 
+    <header name = "fty_mlm" private = "1">Malamute connection helpers</header>
     <class name = "metricinfo" private="1"> Measurement</class>
     <class name = "calc_power" private="1"> Power calculation</class>
     <class name = "tpowerconfiguration" private="1"> Configuration</class>

--- a/src/fty_metric_tpower_classes.h
+++ b/src/fty_metric_tpower_classes.h
@@ -33,6 +33,7 @@
 #include "../include/fty_metric_tpower.h"
 
 //  Extra headers
+#include "fty_mlm.h"
 
 //  Opaque class structures to allow forward references
 #ifndef METRICINFO_T_DEFINED

--- a/src/fty_mlm.h
+++ b/src/fty_mlm.h
@@ -1,0 +1,69 @@
+/*  =========================================================================
+    fty-nut - Malamute connection defaults
+
+    Copyright (C) 2014 - 2018 Eaton
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    =========================================================================
+*/
+
+#ifndef FTY_MLM_H_INCLUDED
+#define FTY_MLM_H_INCLUDED
+
+#include <malamute.h>
+#include <czmq.h>
+
+// C++ wrapper for czmq / malamute objects with automatic cleanup
+// TODO: Move this to fty-common
+template<typename T, void (*destructor)(T**)>
+class MlmObjGuard
+{
+public:
+    MlmObjGuard()
+        : ptr_(nullptr)
+    {}
+    explicit MlmObjGuard(T* ptr)
+        : ptr_(ptr)
+    {}
+    MlmObjGuard(const MlmObjGuard&) = delete;
+    ~MlmObjGuard()
+    {
+        destructor(&ptr_);
+    }
+    T* operator=(T* ptr)
+    {
+        destructor(&ptr_);
+        ptr_ = ptr;
+        return ptr_;
+    }
+    operator T*()
+    {
+        return ptr_;
+    }
+    T* get()
+    {
+        return ptr_;
+    }
+private:
+    T* ptr_;
+};
+
+typedef MlmObjGuard<mlm_client_t, mlm_client_destroy> MlmClientGuard;
+typedef MlmObjGuard<zpoller_t, zpoller_destroy> ZpollerGuard;
+typedef MlmObjGuard<zmsg_t, zmsg_destroy> ZmsgGuard;
+typedef MlmObjGuard<zuuid_t, zuuid_destroy> ZuuidGuard;
+typedef MlmObjGuard<char, zstr_free> ZstrGuard;
+
+#endif


### PR DESCRIPTION
Like in fty-nut, only make the endpoint configurable for potential unit
tests. Also, terminate the service if the malamute connection can't be
set up and let systemd restart it.

BTW, if somebody has better idea how to signal errors from within the actor thread, let me know. Of course I could call exit() or abort() directly.