### PR TITLE
Do not calculate the metrics O(n^2) times in each pass

### DIFF
--- a/src/tpowerconfiguration.h
+++ b/src/tpowerconfiguration.h
@@ -108,6 +108,8 @@ public:
 
     //! \brief send measurement message if needed
     void sendMeasurement(std::map< std::string, TPUnit > &elements, const std::vector<std::string> &quantities );
+    //! \brief send measurement message for a single unit if needed
+    void sendMeasurement(std::pair<const std::string, TPUnit > &elements, const std::vector<std::string> &quantities );
 
     //! \brief powerdevice to DC or rack and put it also in _affected* map
     void addDeviceToMap(


### PR DESCRIPTION
We were asking sendMeasurement() to calculate the metrics of all racks
or DCs... for each rack and DC processed.