### PR TITLE
Problem : sometime client never succeed to reconnect to malamute

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,13 +57,13 @@ EXTRA_DIST += \
 endif
 
 EXTRA_DIST += \
+    src/fty_mlm.h \
     src/metricinfo.h \
     src/calc_power.h \
     src/tpowerconfiguration.h \
     src/metriclist.h \
     src/tp_unit.h \
     src/proto_metric_unavailable.h \
-    src/fty_mlm.h \
     README.md \
     src/fty_metric_tpower_classes.h
 

--- a/project.xml
+++ b/project.xml
@@ -60,7 +60,7 @@
         />
     <!-- use project = "tntdb" test="tntdb::connectCached" header="tntdb/connect.h" / -->
 
-    <header name = "fty_mlm" private = "1">Malamute connection helpers</header>
+    <class name = "fty_mlm" private = "1">Malamute connection helpers</class>
     <class name = "metricinfo" private="1"> Measurement</class>
     <class name = "calc_power" private="1"> Power calculation</class>
     <class name = "tpowerconfiguration" private="1"> Configuration</class>

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -13,6 +13,7 @@ lib_LTLIBRARIES += src/libfty_metric_tpower.la
 pkgconfig_DATA = src/libfty_metric_tpower.pc
 
 src_libfty_metric_tpower_la_SOURCES = \
+    src/fty_mlm.cc \
     src/metricinfo.cc \
     src/calc_power.cc \
     src/tpowerconfiguration.cc \

--- a/src/fty_metric_tpower_server.cc
+++ b/src/fty_metric_tpower_server.cc
@@ -159,6 +159,7 @@ fty_metric_tpower_server (zsock_t *pipe, void* args)
     tpower_conf.configure();
     uint64_t last = zclock_mono ();
     while (!zsys_interrupted) {
+        client.check_connection_alive_or_die();
         void *which = zpoller_wait (poller, tpower_conf.getTimeout());
         uint64_t now = zclock_mono();
         if (now - last >= static_cast<uint64_t>(tpower_conf.getTimeout())) {

--- a/src/fty_mlm.cc
+++ b/src/fty_mlm.cc
@@ -1,0 +1,61 @@
+/*  =========================================================================
+    fty_mlm - Malamute connection helpers
+
+    Copyright (C) 2014 - 2018 Eaton
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    =========================================================================
+*/
+
+/*
+@header
+    fty_mlm - Malamute connection helpers
+@discuss
+@end
+*/
+
+#include "fty_metric_tpower_classes.h"
+#include <sys/types.h>
+
+#define MAX_UNCONNECT_DURATION_MINUTE 5 //minutes
+
+void
+MlmClientGuard::check_connection_alive_or_die()
+{
+    uint64_t     now          = zclock_mono();
+    mlm_client_t *client      = get();
+    if(mlm_client_connected(client)){
+        ts_conn_OK=now;
+        //check if a previous connection was lost
+        if(ts_conn_KO!=0)zsys_info("reconnected to broker");
+        //reset KO counter
+        ts_conn_KO=0;
+    }else{
+        //if we not yet connected, we don't care
+        if(ts_conn_OK==0)return;
+        //detect beginning of disconnection
+        if(ts_conn_KO==0){
+            zsys_warning("malamute broker is unreachable");
+            ts_conn_KO=now;
+        }else
+            //test if coonnection lost for 5 minutes
+            if((now-ts_conn_KO)>MAX_UNCONNECT_DURATION_MINUTE*60*1000){
+            // so decide to die 
+            zsys_error("disconnected from broker for %d minutes, so ABORT !",
+                    MAX_UNCONNECT_DURATION_MINUTE);
+            kill(getpid(),SIGTERM);
+        }
+    }
+}

--- a/src/fty_mlm.h
+++ b/src/fty_mlm.h
@@ -60,7 +60,22 @@ private:
     T* ptr_;
 };
 
-typedef MlmObjGuard<mlm_client_t, mlm_client_destroy> MlmClientGuard;
+class MlmClientGuard: public MlmObjGuard<mlm_client_t, mlm_client_destroy>
+{
+public:
+    using MlmObjGuard::MlmObjGuard;
+    /**
+     * if the connection to malamute broker is lost for more than 5 minutes force
+     * the process to exit.
+     * @return false when connection is lost for more than 5 minutes
+     */
+    void check_connection_alive_or_die();
+
+private:
+    uint64_t ts_conn_OK=0;
+    uint64_t ts_conn_KO=0;
+};
+
 typedef MlmObjGuard<zpoller_t, zpoller_destroy> ZpollerGuard;
 typedef MlmObjGuard<zmsg_t, zmsg_destroy> ZmsgGuard;
 typedef MlmObjGuard<zuuid_t, zuuid_destroy> ZuuidGuard;

--- a/src/fty_mlm.h
+++ b/src/fty_mlm.h
@@ -67,7 +67,6 @@ public:
     /**
      * if the connection to malamute broker is lost for more than 5 minutes force
      * the process to exit.
-     * @return false when connection is lost for more than 5 minutes
      */
     void check_connection_alive_or_die();
 


### PR DESCRIPTION
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>

Problem: 
Sometime something happens wrong and got "unimplemnted command" then the client will retry for ever to reconnect. Unfortunately malmaute will reject for ever all the connection request (deadlock). 
Jun 14 00:00:29 eaton-rc-00505691C353 malamute[1113]: client address='agent-tpower' - unimplemented command
Jun 14 00:00:29 eaton-rc-00505691C353 malamute[1113]: client address='agent-tpower' - de-registering
Jun 14 00:00:29 eaton-rc-00505691C353 malamute[1113]: client address='agent-tpower' - invalid command
Jun 14 00:00:29 eaton-rc-00505691C353 malamute[1113]: client address='agent-tpower' - invalid command
Jun 14 00:00:29 eaton-rc-00505691C353 malamute[1113]: client address='agent-tpower' - invalid command

Solution/Workaround:
As the proper solution could be quite complex to find, try first to do a workaround. 
In this case, wait 5 minutes and die. The systemctl will restart the client and the connection will hopefully succeeded.
 