### PR TITLE
HACK: Abort if we do not receive a message from malamute for 10 minutes (1.4)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -63,6 +63,7 @@ EXTRA_DIST += \
     src/metriclist.h \
     src/tp_unit.h \
     src/proto_metric_unavailable.h \
+    src/watchdog.h \
     README.md \
     src/fty_metric_tpower_classes.h
 

--- a/project.xml
+++ b/project.xml
@@ -67,6 +67,7 @@
     <class name = "tp-unit" private="1"> Power unit </class>
     <class name = "proto-metric-unavailable"    private = "1">metric unavailable protocol send part</class>
     <class name = "fty_metric_tpower_server" state = "stable" >Actor generating new metrics</class>
+    <class name = "watchdog" private = "1" selftest = "0">Watchdog</class>
     <main name = "fty-metric-tpower" service = "1">
         Evaluates some metrics and produces new power metrics
     </main>

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -20,6 +20,7 @@ src_libfty_metric_tpower_la_SOURCES = \
     src/tp_unit.cc \
     src/proto_metric_unavailable.cc \
     src/fty_metric_tpower_server.cc \
+    src/watchdog.cc \
     src/platform.h
 
 if ENABLE_DRAFTS

--- a/src/fty_metric_tpower_classes.h
+++ b/src/fty_metric_tpower_classes.h
@@ -59,6 +59,10 @@ typedef struct _tp_unit_t tp_unit_t;
 typedef struct _proto_metric_unavailable_t proto_metric_unavailable_t;
 #define PROTO_METRIC_UNAVAILABLE_T_DEFINED
 #endif
+#ifndef WATCHDOG_T_DEFINED
+typedef struct _watchdog_t watchdog_t;
+#define WATCHDOG_T_DEFINED
+#endif
 
 //  Internal API
 
@@ -68,6 +72,7 @@ typedef struct _proto_metric_unavailable_t proto_metric_unavailable_t;
 #include "metriclist.h"
 #include "tp_unit.h"
 #include "proto_metric_unavailable.h"
+#include "watchdog.h"
 
 //  *** To avoid double-definitions, only define if building without draft ***
 #ifndef FTY_METRIC_TPOWER_BUILD_DRAFT_API

--- a/src/fty_metric_tpower_server.cc
+++ b/src/fty_metric_tpower_server.cc
@@ -97,6 +97,10 @@ fty_metric_tpower_server (zsock_t *pipe, void* args)
 
     mlm_client_t *client = mlm_client_new ();
 
+    // Setup the watchdog
+    Watchdog watchdog;
+    watchdog.start();
+
     zpoller_t *poller = zpoller_new (pipe, mlm_client_msgpipe(client), NULL);
 
     // Signal need to be send as it is required by "actor_new"
@@ -216,6 +220,9 @@ fty_metric_tpower_server (zsock_t *pipe, void* args)
                 zsys_error ("cannot decode fty_proto message, ignore it");
                 continue;
             }
+            // As long as we are receiving metrics from malamute, everything
+            // is fine
+            watchdog.tick();
             if (fty_proto_id (bmessage) == FTY_PROTO_METRIC)  {
                 s_processMetric (tpower_conf, topic, &bmessage);
             }

--- a/src/watchdog.cc
+++ b/src/watchdog.cc
@@ -1,0 +1,83 @@
+/*  =========================================================================
+    watchdog - Watchdog
+
+    Copyright (C) 2014 - 2018 Eaton
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    =========================================================================
+*/
+
+/*
+@header
+    watchdog - Watchdog
+@discuss
+@end
+*/
+
+#include "watchdog.h"
+
+#define WATCHDOG_INTERVAL 60
+#define WATCHDOG_LIMIT 600
+
+Watchdog::Watchdog()
+    : thread_(0)
+{
+}
+
+Watchdog::~Watchdog()
+{
+    zactor_destroy(&thread_);
+}
+
+static void watchdog_thread(zsock_t *pipe, void* args)
+{
+    Watchdog *wd = static_cast<Watchdog*>(args);
+
+    zsock_signal(pipe, 0);
+    zpoller_t *poller = zpoller_new(pipe, NULL);
+    while (!zsys_interrupted) {
+        void *which = zpoller_wait(poller, WATCHDOG_INTERVAL);
+        if (which == pipe) {
+            zmsg_t *msg = zmsg_recv(pipe);
+            char *cmd = zmsg_popstr(msg);
+            if (streq(cmd, "$TERM")) {
+                zstr_free(&cmd);
+                zmsg_destroy(&msg);
+                break;
+            }
+            zstr_free(&cmd);
+            zmsg_destroy(&msg);
+            wd->tick();
+        } else if (wd->check()) {
+            continue;
+        }
+        zsys_error("watchdog expired");
+        exit(2);
+    }
+    zpoller_destroy(&poller);
+}
+
+void Watchdog::start()
+{
+    tick();
+    thread_ = zactor_new(watchdog_thread, this);
+    assert(thread_);
+}
+
+bool Watchdog::check()
+{
+    return last_tick_.load() + WATCHDOG_LIMIT > zclock_mono() / 1000;
+}
+

--- a/src/watchdog.h
+++ b/src/watchdog.h
@@ -1,0 +1,46 @@
+/*  =========================================================================
+    watchdog - Watchdog
+
+    Copyright (C) 2014 - 2018 Eaton
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    =========================================================================
+*/
+
+#ifndef WATCHDOG_H_INCLUDED
+#define WATCHDOG_H_INCLUDED
+
+#include <sys/types.h>
+#include <atomic>
+#include <czmq.h>
+
+
+// Band-aid for malamute going AWOL
+class Watchdog {
+public:
+    Watchdog();
+    ~Watchdog();
+    void start();
+    void tick()
+    {
+        last_tick_.store(zclock_mono() / 1000);
+    }
+    bool check();
+private:
+    std::atomic<time_t> last_tick_;
+    zactor_t *thread_;
+};
+
+#endif


### PR DESCRIPTION
This is a band-aid for 1.4, where we have issues that the connection
with malamute breaks for some reason. Normally, we should be receiving
metrics from fty-nut and others each 30 seconds. If we receive nothing
for 10 minutes, it is a clear indication that something went wrong. Stop
the agent and let systemd start it anew.